### PR TITLE
Show next percentage even if it's less than previous

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function ProgressBarPlugin(options) {
 
     var newPercent = Math.ceil(percent * barOptions.width);
 
-    if (lastPercent !== newPercent && newPercent > lastPercent) {
+    if (lastPercent !== newPercent) {
       if (isInteractive) {
         bar.update(percent);
       } else {


### PR DESCRIPTION
This is the current behaviour:
![progress01](https://cloud.githubusercontent.com/assets/2177366/12363315/2d0ed722-bb96-11e5-8586-8566c0ccd1bb.gif)

Progress reaches 70% early, but does not update until the calculated progress goes over 70% near the end of the build.

With the change in this PR:
![progress02](https://cloud.githubusercontent.com/assets/2177366/12363314/2d04d920-bb96-11e5-902a-4ffbf4534d6f.gif)

When progress is corrected to 20%, it's shown in the progress bar.
