### PR TITLE
Allow configuring `stream` of `ProgressBar`

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = function ProgressBarPlugin(options) {
 
   delete options.format;
   delete options.total;
-  delete options.stream;
   delete options.summary;
   delete options.summaryContent;
   delete options.customSummary;


### PR DESCRIPTION
Because the `stream` was deleted from `options`, the `ProgressBar` was defaulting to process.stderr. This PR enables the `stream` option to be passed in.
