### PR TITLE
Add webpack 3 as valid peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "progress": "^1.1.8"
   },
   "peerDependencies": {
-    "webpack": "^1.3.0 || ^2 || ^2.1.0-beta || ^2.2.0-rc"
+    "webpack": "^1.3.0 || ^2 || ^3"
   }
 }


### PR DESCRIPTION
Now that webpack 3 is out, we can bump webpack version in peerDependencies so users can update.

It also remove webpack 2.1.0-beta and 2.2.0-rc from peerDependencies since I don't think it's relevant anymore.