### PR TITLE
Fixed timing reset when using wepack watch and multiple configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function ProgressBarPlugin(options) {
 
     var newPercent = Math.ceil(percent * barOptions.width);
 
-    if (lastPercent !== newPercent) {
+    if (lastPercent < newPercent || newPercent === 0) {
       bar.update(percent, {
         msg: msg
       });


### PR DESCRIPTION
1.  Fixed timing not being reset between webpack watch builds
2. Fixed progress percentage 'jumping' with multiple webpack configurations



